### PR TITLE
Add action to check json format

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,15 @@
+---
+name: Check Json format
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,5 +12,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,5 +1,5 @@
 ---
-name: Check Json formatting
+name: Check JSON formatting
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,5 +1,5 @@
 ---
-name: Check Json format
+name: Check Json formatting
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,4 +16,5 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.11
-    - uses: pre-commit/action@v3.0.0
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,6 +10,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out repository
+      uses: actions/checkout@v4
     - uses: actions/setup-python@v4
     - uses: pre-commit/action@v3.0.0

--- a/schema.json
+++ b/schema.json
@@ -1,34 +1,34 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "array",
-    "minItems": 1,
-    "uniqueItems": true,
-    "items": {
-        "type": "object",
-        "properties": {
-            "package_name": {"type": "string"},
-            "version": {
-                "type": "string",
-                "_comment": "PEP404 version string prefixed with a comparison operator, Excluding trailing '.*'.\nhttps://peps.python.org/pep-0440/#version-specifiers\nhttps://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions",
-                "pattern": "^(~=|==|!=|<=|>=|<|>|===)\\s*([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?$"
-            },
-            "approval_date": {
-                "type": "string",
-                "format": "date"
-            },
-            "revoke_date": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        },
-        "required": ["package_name", "version", "approval_date", "revoke_date"],
-        "additionalProperties": false
-    }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "package_name": { "type": "string" },
+      "version": {
+        "type": "string",
+        "_comment": "PEP404 version string prefixed with a comparison operator, Excluding trailing '.*'.\nhttps://peps.python.org/pep-0440/#version-specifiers\nhttps://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions",
+        "pattern": "^(~=|==|!=|<=|>=|<|>|===)\\s*([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?$"
+      },
+      "approval_date": {
+        "type": "string",
+        "format": "date"
+      },
+      "revoke_date": {
+        "oneOf": [
+          {
+            "type": "string",
+            "format": "date"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": ["package_name", "version", "approval_date", "revoke_date"],
+    "additionalProperties": false
+  }
 }

--- a/schema_other.json
+++ b/schema_other.json
@@ -1,38 +1,44 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "array",
-    "minItems": 1,
-    "uniqueItems": true,
-    "items": {
-        "type": "object",
-        "properties": {
-            "package_name": {"type": "string"},
-            "url": {
-                "type": "string",
-                "format": "uri"
-            },
-            "version": {
-                "type": "string",
-                "_comment": "PEP404 version string prefixed with a comparison operator, Excluding trailing '.*'.\nhttps://peps.python.org/pep-0440/#version-specifiers\nhttps://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions",
-                "pattern": "^(~=|==|!=|<=|>=|<|>|===)\\s*([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?$"
-            },
-            "approval_date": {
-                "type": "string",
-                "format": "date"
-            },
-            "revoke_date": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        },
-        "required": ["package_name", "url", "version", "approval_date", "revoke_date"],
-        "additionalProperties": false
-    }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "package_name": { "type": "string" },
+      "url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "version": {
+        "type": "string",
+        "_comment": "PEP404 version string prefixed with a comparison operator, Excluding trailing '.*'.\nhttps://peps.python.org/pep-0440/#version-specifiers\nhttps://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions",
+        "pattern": "^(~=|==|!=|<=|>=|<|>|===)\\s*([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?$"
+      },
+      "approval_date": {
+        "type": "string",
+        "format": "date"
+      },
+      "revoke_date": {
+        "oneOf": [
+          {
+            "type": "string",
+            "format": "date"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "required": [
+      "package_name",
+      "url",
+      "version",
+      "approval_date",
+      "revoke_date"
+    ],
+    "additionalProperties": false
+  }
 }


### PR DESCRIPTION
Adds a pre-commit Github action to highlight JSON formatting issues automatically when pull requests are created. Alternatively, it's probably possible to incorporate this into the validation workflow.